### PR TITLE
config: headers_list: provide sensible default

### DIFF
--- a/lib/open_api_rack/configuration.rb
+++ b/lib/open_api_rack/configuration.rb
@@ -2,7 +2,7 @@ module OpenApiRack
   class Configuration
     attr_accessor :headers_list, :disable_by_default
 
-    def initialize(headers_list = nil, disable_by_default = false)
+    def initialize(headers_list = [], disable_by_default = false)
       @headers_list = headers_list
       @disable_by_default = disable_by_default
     end


### PR DESCRIPTION
Currently the middleware crashes if the developer doesn't set `headers_list`.