### PR TITLE
use YAML.dump instead of Hash#to_yaml

### DIFF
--- a/lib/open_api_rack/middleware.rb
+++ b/lib/open_api_rack/middleware.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 module OpenApiRack
   class Middleware
     def initialize(app)
@@ -72,7 +74,7 @@ module OpenApiRack
       )
 
       File.open('public/open-api.yaml', 'w') do |f|
-        f.write(open_api_hash.to_yaml)
+        f.write YAML.dump open_api_hash
       end
 
       app_call_result


### PR DESCRIPTION
the #to_yaml method is not provided by the declared dependencies, it's an undeclared dependency on ActiveSupport